### PR TITLE
音声アイコンとフォントが適用されない問題の修正

### DIFF
--- a/js/hitsuji_game.js
+++ b/js/hitsuji_game.js
@@ -75,7 +75,6 @@ export default class HitsujiGame extends Phaser.Scene {
     this.events.on("resume", (scene, data) => {
       switch (data.status) {
         case "restart":
-          this.registry.destroy();
           this.events.off();
           this.scene.stop();
           this.scene.start("hitsuji_game", {
@@ -86,13 +85,11 @@ export default class HitsujiGame extends Phaser.Scene {
           });
           break;
         case "return-to-top":
-          this.registry.destroy();
           this.events.off();
           this.scene.stop();
           this.scene.start("game_menu");
           break;
         case "finish-game":
-          this.registry.destroy();
           this.events.off();
           this.scene.stop();
           this.scene.start("game_menu");

--- a/js/sound_button.js
+++ b/js/sound_button.js
@@ -21,9 +21,10 @@ export default class SoundButton extends Phaser.GameObjects.Container {
     this.muteIcon.setVisible(scene.sound.mute);
 
     this.soundCircle.on("pointerdown", () => {
-      scene.sound.setMute(!scene.sound.mute);
-      this.soundIcon.setVisible(!scene.sound.mute);
-      this.muteIcon.setVisible(scene.sound.mute);
+      const isMute = !scene.sound.mute;
+      scene.sound.setMute(isMute);
+      this.soundIcon.setVisible(!isMute);
+      this.muteIcon.setVisible(isMute);
     });
 
     this.add([this.soundCircle, this.soundIcon, this.muteIcon]);


### PR DESCRIPTION
- chromium系ブラウザで音声のアイコンのon/offが逆になるバグの修正
- ポーズ画面からトップに戻ってもフォントの設定を破棄しないように修正