### PR TITLE
プレイ画面の各コンポーネントの位置調整など

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       * {
           margin: 0;
 	        padding: 0;
+          background-color: #f5f5f5;
       }
     </style> 
   </head>

--- a/js/hitsuji_game.js
+++ b/js/hitsuji_game.js
@@ -292,26 +292,27 @@ export default class HitsujiGame extends Phaser.Scene {
     if (this.answerComponent) this.answerComponent.destroy();
 
     if (this.mode === "suddenDeath") {
-      this.answerComponent = this.add
-        .text(360, 671, `正解数:${this.answerCounter}問`, {
+      this.answerComponent = this.add.text(
+        155,
+        671,
+        `正解数：${this.answerCounter}問`,
+        {
           fill: 0x333333,
           fontSize: 50,
           fontFamily: this.fontFamily,
-        })
-        .setOrigin(1, 0);
+        }
+      );
     } else if (this.mode === "timeAttack" || this.mode === "timeLimit") {
-      this.answerComponent = this.add
-        .text(
-          360,
-          671,
-          `残り:${this.kanjiList.length - this.answerCounter}問`,
-          {
-            fill: 0x333333,
-            fontSize: 50,
-            fontFamily: this.fontFamily,
-          }
-        )
-        .setOrigin(1, 0);
+      this.answerComponent = this.add.text(
+        155,
+        671,
+        `残り：${this.kanjiList.length - this.answerCounter}問`,
+        {
+          fill: 0x333333,
+          fontSize: 50,
+          fontFamily: this.fontFamily,
+        }
+      );
     }
   }
 

--- a/js/hitsuji_game.js
+++ b/js/hitsuji_game.js
@@ -113,11 +113,6 @@ export default class HitsujiGame extends Phaser.Scene {
           this.scene.stop();
           this.scene.start("game_menu");
           break;
-        case "finish-game":
-          this.events.off();
-          this.scene.stop();
-          this.scene.start("game_menu");
-          break;
         default:
       }
     });


### PR DESCRIPTION
# 変更点
## 回答数/問題数の表示を変更した
setOriginが不要なので外したかった

## 漢字を中央を基準に配置されるように変更
漢字の数を少ないに設定すると微妙に中央揃えでなかった

## CSSで背景色をつけた
デザイン上ついていたから、あまり変わらない

## リファクタリング
漢字の位置をContainerを使って補正するようにした
それに伴って、いままで配列で管理していた漢字のオブジェクトをContainerで管理するように変更した