### PR TITLE
ポーズ画面のメニューに「設定画面に戻る」を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 
       * {
           margin: 0;
-	        padding: 0;
+          padding: 0;
           background-color: #f5f5f5;
       }
     </style> 

--- a/js/game_setting.js
+++ b/js/game_setting.js
@@ -19,10 +19,32 @@ export default class GameSetting extends Phaser.Scene {
     this.load.audio("game_start_se", "audio/game_start.mp3");
   }
 
-  init() {
+  init(data) {
     this.size = "ふつう";
     this.mode = "時間制限";
     this.schoolYear = "1年生";
+
+    if (data.sizeY) {
+      switch (data.sizeY) {
+        case 3:
+          this.size = "少ない";
+          break;
+        case 6:
+          this.size = "多い";
+          break;
+        default:
+      }
+    }
+    if (data.mode) {
+      switch (data.mode) {
+        case "timeAttack":
+          this.mode = "タイムアタック";
+          break;
+        default:
+      }
+    }
+    if (data.schoolYear) this.schoolYear = data.schoolYear;
+
     this.selectedSettingCategory = "size";
     this.challenge = false;
     this.categoryButtons = [];

--- a/js/hitsuji_game.js
+++ b/js/hitsuji_game.js
@@ -113,6 +113,16 @@ export default class HitsujiGame extends Phaser.Scene {
           this.scene.stop();
           this.scene.start("game_menu");
           break;
+        case "return-to-setting":
+          this.events.off();
+          this.scene.stop();
+          this.scene.start("game_setting", {
+            sizeY: this.sizeY,
+            sizeX: this.sizeX,
+            mode: this.mode,
+            schoolYear: this.schoolYear,
+          });
+          break;
         default:
       }
     });

--- a/js/pause_menu.js
+++ b/js/pause_menu.js
@@ -16,7 +16,7 @@ export default class PauseMenu extends Phaser.Scene {
     };
 
     this.add
-      .text(halfOfSceneWidth, 250, "再開する", textStyle)
+      .text(halfOfSceneWidth, 200, "再開する", textStyle)
       .setOrigin(0.5, 0)
       .setInteractive()
       .once(
@@ -29,7 +29,7 @@ export default class PauseMenu extends Phaser.Scene {
       );
 
     this.add
-      .text(halfOfSceneWidth, 362, "やり直す", textStyle)
+      .text(halfOfSceneWidth, 312, "やり直す", textStyle)
       .setOrigin(0.5, 0)
       .setInteractive()
       .once(
@@ -44,7 +44,20 @@ export default class PauseMenu extends Phaser.Scene {
       );
 
     this.add
-      .text(halfOfSceneWidth, 474, "トップへ戻る", textStyle)
+      .text(halfOfSceneWidth, 424, "設定画面へ戻る", textStyle)
+      .setOrigin(0.5, 0)
+      .setInteractive()
+      .once(
+        "pointerdown",
+        () => {
+          this.scene.resume("hitsuji_game", { status: "return-to-setting" });
+          this.scene.stop();
+        },
+        this
+      );
+
+    this.add
+      .text(halfOfSceneWidth, 536, "トップへ戻る", textStyle)
       .setOrigin(0.5, 0)
       .setInteractive()
       .once(


### PR DESCRIPTION
## ポーズ画面のメニューに「設定画面に戻る」を追加
そもそもデザインにはあった
設定画面に戻った時に戻る前のゲームの設定を反映させる