### PR TITLE
113 hitsuji font

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,9 @@
     };
   </script>
   <link rel="stylesheet" href="style.css"/>
-  <link rel="preconnect" href="https://fonts.gstatic.com"> 
-  <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@700&display=swap" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Klee+One:wght@600&display=swap" rel="stylesheet">
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -11,10 +11,13 @@
     };
   </script>
   <link rel="stylesheet" href="style.css"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com"> 
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@700&display=swap" rel="stylesheet">
 </head>
 
 <body>
-	<div id="app" style="font-family: 'UD デジタル 教科書体 NP-R', 'KleeOne'"></div>
+  <!--  style="font-family: 'UD デジタル 教科書体 NP-R', 'KleeOne'" -->
+	<div id="app"></div>
   <div id="game"></div>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-68PVBL7TST"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -63,8 +63,12 @@ const config = {
 // export default new Phaser.Game(config)
 const game = new Phaser.Game(config);
 game.registry.set(
+  "kanjiFontFamily",
+  "'Noto Serif JP', serif"
+);
+game.registry.set(
   "fontFamily",
-  "'UD デジタル 教科書体 NP-R', KleeOne, Arial, Sarabun"
+  "'sans-serif', KleeOne, Arial, Sarabun"
 );
 
 export default game;

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ const config = {
 const game = new Phaser.Game(config);
 game.registry.set(
   "kanjiFontFamily",
-  "'Noto Serif JP', serif"
+  "'Klee One', cursive"
 );
 game.registry.set(
   "fontFamily",

--- a/src/scenes/ui/KanjiContainer.js
+++ b/src/scenes/ui/KanjiContainer.js
@@ -316,7 +316,7 @@ export default class KanjiContainer extends Phaser.GameObjects.Container {
             .text(x * this.kanjiSpace, y * this.kanjiSpace, kanji, {
               fill: 0x333333,
               fontSize: this.kanjiFontSize,
-              fontFamily: scene.registry.get("fontFamily"),
+              fontFamily: scene.registry.get("kanjiFontFamily"),
             })
             .setInteractive()
         );


### PR DESCRIPTION
漢字部分のフォントはgoogle fontsから持ってきた教科書体に似たものを使用。
それ以外はゴシック体を適用。
main.jsにてフォントの変数を漢字部分とそれ以外の２つに分けて実現。

しかし漢字部分のフォントの読み込み及び適用に異常な時間がかかっているのか、
同じ漢字でもフォントが普通のゴシック体になったり教科書体になったりと一貫していません。
そこで、他PCでも同様な状態になるか試してみてほしいです。