### PR TITLE
フォント適用速度改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,15 +10,12 @@
       if (location.search != "") location.href = "/";
     };
   </script>
-  <link rel="stylesheet" href="style.css"/>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Klee+One:wght@600&display=swap" rel="stylesheet">
+  <link rel="preload" as="style" href="style.css"/>
+  <link rel="stylesheet" href="style.css" media="print" onload="this.media='all'" />
 </head>
 
 <body>
-  <!--  style="font-family: 'UD デジタル 教科書体 NP-R', 'KleeOne'" -->
-	<div id="app"></div>
+	<div id="app" style="font-family: KleeOne;"></div>
   <div id="game"></div>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-68PVBL7TST"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ const config = {
 const game = new Phaser.Game(config);
 game.registry.set(
   "kanjiFontFamily",
-  "'Klee One', cursive"
+  "KleeOne"
 );
 game.registry.set(
   "fontFamily",

--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 @font-face {
-  font-family: KleeOne;
-  src: url("assets/font/KleeOne-SemiBold.ttf");
+  src: url("assets/font/KleeOne-SemiBold.ttf") format("truetype");
+  font-family: "KleeOne";
 }
 
 * {


### PR DESCRIPTION
フォントの一貫性がなかった理由として、google fontsの読み込みの遅さもありますが何より、
使用しようとしていたフォントが既にローカルにダウンロードされており、それと競合してしまっていたようです。
そこでgoogle fontsのリンクを消してローカルにある「KleeOne」のフォントを漢字部分に適応させ、
更にstyle.cssとindex.htmlに処理速度アップの処理を施しました。