### PR TITLE
テキスト変更＆座標調整

### DIFF
--- a/src/scenes/game_setting.js
+++ b/src/scenes/game_setting.js
@@ -228,7 +228,7 @@ export default class GameSetting extends Phaser.Scene {
 
       // 出てくる漢字
       this.add
-        .text(163, 463, "出てくる漢字", {
+        .text(180, 463, "漢字レベル", {
           fontSize: "32px",
           fontFamily: this.fontFamily,
         })


### PR DESCRIPTION
scenes/game_setting.js内のcreateCategoryButtonの箇所を変更。
「漢字レベル」に変更はできましたが座標にずれがあったため、大体中央であろうと思われる箇所に目分量調整しました。