### PR TITLE
ボタン色変更&単位の見直し

### DIFF
--- a/src/scenes/game_menu.js
+++ b/src/scenes/game_menu.js
@@ -188,7 +188,7 @@ export default class GameMenu extends Phaser.Scene {
     const mnyLngButton = this.add.graphics();
     mnyLngButton
       .lineStyle(2, 0x645246)
-      .fillStyle(0x32b65e, 1)
+      .fillStyle(0xffffff, 1)
       .fillRoundedRect(30, 230, 350, 90, 45)
       .setInteractive(
         new Phaser.Geom.Rectangle(30, 230, 350, 90),
@@ -199,7 +199,7 @@ export default class GameMenu extends Phaser.Scene {
     this.add.text(120, 260, "世界の文字", {
       fontSize: "32px",
       fontFamily: this.fontFamily,
-      color: "#ffffff",
+      color: "#333333",
     });
 
     mnyLngButton.on(
@@ -215,7 +215,7 @@ export default class GameMenu extends Phaser.Scene {
     const tgtherFriendButton = this.add.graphics();
     tgtherFriendButton
       .lineStyle(2, 0x645246)
-      .fillStyle(0x32b65e, 1)
+      .fillStyle(0xffffff, 1)
       .fillRoundedRect(30, 360, 350, 90, 45)
       .setInteractive(
         new Phaser.Geom.Rectangle(30, 360, 350, 90),
@@ -231,7 +231,7 @@ export default class GameMenu extends Phaser.Scene {
       .text(200, 390, "仲間で集まれ", {
         fontSize: "32px",
         fontFamily: this.fontFamily,
-        color: "#ffffff",
+        color: "#333333",
       })
       .setOrigin(0.5, 0);
 
@@ -239,7 +239,7 @@ export default class GameMenu extends Phaser.Scene {
     const memoryGmButton = this.add.graphics();
     memoryGmButton
       .lineStyle(2, 0x645246)
-      .fillStyle(0x32b65e, 1)
+      .fillStyle(0xffffff, 1)
       .fillRoundedRect(30, 490, 350, 90, 45)
       .setInteractive(
         new Phaser.Geom.Rectangle(30, 490, 350, 90),
@@ -250,7 +250,7 @@ export default class GameMenu extends Phaser.Scene {
       .text(200, 520, "作成中", {
         fontSize: "32px",
         fontFamily: this.fontFamily,
-        color: "#ffffff",
+        color: "#333333",
       })
       .setOrigin(0.5, 0);
 

--- a/src/scenes/sekai_game.js
+++ b/src/scenes/sekai_game.js
@@ -348,14 +348,14 @@ export default class SekaiGame extends Phaser.Scene {
           fontFamily: this.fontFamily,
         })
         .setOrigin(0.5, 0);
-    } else if (this.prevSceneData.mode === "learn") {
+    /*} else if (this.prevSceneData.mode === "learn") {
       this.timerComponent = this.add
         .text(this.game.canvas.width / 2, 54, `タイム：${time}秒`, {
           color: "#333333",
           fontSize: "50px",
           fontFamily: this.fontFamily,
         })
-        .setOrigin(0.5, 0);
+        .setOrigin(0.5, 0);*/
     }
   }
 

--- a/src/scenes/sekai_game_result.js
+++ b/src/scenes/sekai_game_result.js
@@ -138,7 +138,7 @@ export default class SekaiGameResult extends Phaser.Scene {
           return "";
       }
     })();
-    const text2 = this.prevSceneData.mode === "suddenDeath" ? " 問" : " 秒";
+    const text2 = this.prevSceneData.mode === "suddenDeath" || "learn" ? " 問" : " 秒";
 
     const text1Object = this.add.text(0, 22, text1, {
       color: "#333333",


### PR DESCRIPTION
- トップのボタンの色を背景白、文字黒に変更
- 世界の文字の際、学習モードのタイム表示消去
- 世界の文字のリザルトにて、学習モードの際は正解数の単位をサドンデスと同じ「問」に変更(論理演算子ORにて実現)