### PR TITLE
韓国語非表示問題

### DIFF
--- a/src/characterlist.js
+++ b/src/characterlist.js
@@ -303,7 +303,7 @@ export const characterList = {
       },
     },
   ],
-  韓国語_ハングル: [
+  韓国語: [
     {
       number: 1,
       correct: {


### PR DESCRIPTION
世界の文字 韓国語を選択しても非表示になる問題を解決
characterlist.jsでの文字スペルミスが原因